### PR TITLE
Enable profile-based console logging

### DIFF
--- a/src/main/java/jkt/pls/handler/SearchHandler.java
+++ b/src/main/java/jkt/pls/handler/SearchHandler.java
@@ -12,18 +12,20 @@ import jkt.pls.model.request.InsertRequest;
 import jkt.pls.model.request.SearchRequest;
 import jkt.pls.service.SearchService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class SearchHandler {
 	
 	private final SearchService searchService;
 	
-	public Mono<ServerResponse> list(ServerRequest serverRequest){
-		
-		System.out.println("SearchHandler.list");
-		String keyword = serverRequest.queryParam("keyword").orElse("");
+        public Mono<ServerResponse> list(ServerRequest serverRequest){
+
+                log.info("SearchHandler.list");
+                String keyword = serverRequest.queryParam("keyword").orElse("");
 		
 		return searchService.list(new SearchRequest())
 			.collectList()
@@ -78,9 +80,9 @@ public class SearchHandler {
 		            .bodyValue(s)
 			)
 			// 오류 예외처리
-			.onErrorResume(RuntimeException.class, ex -> {
-				ex.printStackTrace();
-				return ServerResponse.status(HttpStatus.UNAUTHORIZED)
+                        .onErrorResume(RuntimeException.class, ex -> {
+                                log.error("Insert failed", ex);
+                                return ServerResponse.status(HttpStatus.UNAUTHORIZED)
 					.contentType(MediaType.APPLICATION_JSON)
 					.bodyValue(Map.of(
 							"message", ex.getMessage()

--- a/src/main/java/jkt/pls/service/SearchService.java
+++ b/src/main/java/jkt/pls/service/SearchService.java
@@ -7,11 +7,13 @@ import jkt.pls.model.request.SearchRequest;
 import jkt.pls.repository.ProjectRepository;
 import jkt.pls.repository.SearchRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SearchService {
 	
 //	@Value("${custom.document.path}")
@@ -23,8 +25,8 @@ public class SearchService {
 	
 	public Flux<?> list(SearchRequest request){
 		
-		long cnt = 0;
-		System.out.println("SearchService.list");
+                long cnt = 0;
+                log.info("SearchService.list");
 		
 		return searchRepository.findAll();
 		

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,3 @@
+logging:
+  level:
+    jkt.pls: OFF

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,8 @@ logging:
     io:
       r2dbc:
         h2: DEBUG
+    jkt:
+      pls: INFO
 
 management:
   endpoints:


### PR DESCRIPTION
## Summary
- add SLF4J logging to `SearchHandler` and `SearchService`
- log errors on failures
- set default logging level for the project
- add `application-prod.yml` to disable logs in production

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e080833883248f313e15efbd3967